### PR TITLE
WifiVendorHal: Use WifiHandlerThread to register destroyed listener

### DIFF
--- a/service/java/com/android/server/wifi/WifiVendorHal.java
+++ b/service/java/com/android/server/wifi/WifiVendorHal.java
@@ -440,7 +440,8 @@ public class WifiVendorHal {
     public String createStaIface(InterfaceDestroyedListener destroyedListener) {
         synchronized (sLock) {
             IWifiStaIface iface = mHalDeviceManager.createStaIface(
-                    new StaInterfaceDestroyedListenerInternal(destroyedListener), null);
+                    new StaInterfaceDestroyedListenerInternal(destroyedListener),
+                    getHandlerForStaSapConcurrency());
             if (iface == null) {
                 mLog.err("Failed to create STA iface").flush();
                 return stringResult(null);
@@ -518,7 +519,8 @@ public class WifiVendorHal {
     public String createApIface(InterfaceDestroyedListener destroyedListener) {
         synchronized (sLock) {
             IWifiApIface iface = mHalDeviceManager.createApIface(
-                    new ApInterfaceDestroyedListenerInternal(destroyedListener), null);
+                    new ApInterfaceDestroyedListenerInternal(destroyedListener),
+                    getHandlerForStaSapConcurrency());
             if (iface == null) {
                 mLog.err("Failed to create AP iface").flush();
                 return stringResult(null);


### PR DESCRIPTION
During Create Ap/Sta Iface, WifiVendorHal doesn't pass handler
thread context. Thus, onDestroyed() is called in caller's thread
context. Ex, CreateP2pInterface would call (2nd) Station's
onDestroyed in WifiP2pService context. In specific scenario, it
would lead to cyclic locking between WifiHandlerThread and Wifi
P2P Service thread, resulting to deadlock.

This commit passes WifiHandlerThread to CreateApIface/CreateStaIface
API call, similar to CreateP2pIface/CreateNanIface, so that
onDesotryed() would be called in WifiHanderThread context only for
the targets where STA+SAP concurrency is allowed.

CRs-Fixed: 2795767
Change-Id: I8a6c64d5d0a7d105991ec1e87ef2c9a06b113a51